### PR TITLE
refactor: cleanup code, better building

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "mini-http",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "a very tiny, very fragile http server. you shouldn't use this",
   "scripts": {
     "build": "esbuild src/index.ts --platform=node --bundle --outdir=dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./server";
+export * from "./typed-server";
 export * from "./errors";
 export * from "./http";
 export * from "./logger";

--- a/src/typed-server.spec.ts
+++ b/src/typed-server.spec.ts
@@ -7,7 +7,7 @@ import { Logger } from "./logger";
 
 import { createTypedHttpServer, TypedHttpServer } from "./typed-server";
 
-const testServers: TypedHttpServer<any>[] = [];
+const testServers: TypedHttpServer[] = [];
 
 const defaultLogger = new Proxy(
   {},

--- a/src/typed-server.spec.ts
+++ b/src/typed-server.spec.ts
@@ -1,4 +1,7 @@
-import { get, IncomingMessage } from "http";
+import { get, request, IncomingMessage } from "node:http";
+
+import { Static, Type } from "@sinclair/typebox";
+
 import { AuthError } from "./errors";
 import { Logger } from "./logger";
 
@@ -43,6 +46,24 @@ async function httpGet(
       res.on("data", (chunk) => (data += chunk));
       res.on("end", () => resolve({ status: res.statusCode, data, raw: res }));
     }).on("error", reject);
+  });
+}
+
+async function httpPost(
+  url: URL,
+  data: unknown
+): Promise<{ status?: number; data: string; raw: IncomingMessage }> {
+  const options = {
+    method: "POST",
+  };
+  return new Promise((resolve, reject) => {
+    const req = request(url, options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => resolve({ status: res.statusCode, data, raw: res }));
+    }).on("error", reject);
+    req.write(JSON.stringify(data));
+    req.end();
   });
 }
 
@@ -97,6 +118,71 @@ describe("createHttpServer", () => {
     expect(response).toBeDefined();
     expect(response.status).toBe(200);
     expect(response.data).toBe("hello world");
+  });
+
+  it("should add a typed route", async () => {
+    const port = portGen.next().value;
+    const server = createTestHttpServer({ port, logger: defaultLogger });
+
+    const schema = Type.Object({
+      foo: Type.String(),
+      bar: Type.Number(),
+    });
+
+    server.addTypedRoute({
+      matcher: "POST /",
+      schema: {
+        body: schema,
+      },
+      async handler(request, route) {
+        return {
+          status: 200,
+          body: "hello world",
+        };
+      },
+    });
+
+    await server.start();
+
+    const url = new URL(`http://localhost:${port}/`);
+
+    const response = await httpPost(url, { foo: "str", bar: 1 });
+
+    expect(response).toBeDefined();
+    expect(response.status).toBe(200);
+    expect(response.data).toBe("hello world");
+  });
+
+  it("should return 400 when payload is invalid", async () => {
+    const port = portGen.next().value;
+    const server = createTestHttpServer({ port, logger: defaultLogger });
+
+    const schema = Type.Object({
+      foo: Type.String(),
+      bar: Type.Number(),
+    });
+
+    server.addTypedRoute({
+      matcher: "POST /",
+      schema: {
+        body: schema,
+      },
+      async handler(request, route) {
+        return {
+          status: 200,
+          body: "hello world",
+        };
+      },
+    });
+
+    await server.start();
+
+    const url = new URL(`http://localhost:${port}/`);
+
+    const response = await httpPost(url, {});
+
+    expect(response).toBeDefined();
+    expect(response.status).toBe(400);
   });
 
   it("should return 401 when auth error is thrown", async () => {

--- a/src/typed-server.spec.ts
+++ b/src/typed-server.spec.ts
@@ -2,9 +2,9 @@ import { get, IncomingMessage } from "http";
 import { AuthError } from "./errors";
 import { Logger } from "./logger";
 
-import { createHttpServer, HttpServer } from "./server";
+import { createTypedHttpServer, TypedHttpServer } from "./typed-server";
 
-const testServers: HttpServer[] = [];
+const testServers: TypedHttpServer<any>[] = [];
 
 const defaultLogger = new Proxy(
   {},
@@ -24,8 +24,8 @@ function* portGenerator(): Generator<number> {
 
 const portGen = portGenerator();
 
-const createTestHttpServer: typeof createHttpServer = (...args) => {
-  const server = createHttpServer(...args);
+const createTestHttpServer: typeof createTypedHttpServer = (...args) => {
+  const server = createTypedHttpServer(...args);
   testServers.push(server);
   return server;
 };

--- a/src/typed-server.ts
+++ b/src/typed-server.ts
@@ -1,0 +1,144 @@
+import { once } from "node:events";
+import { IncomingMessage } from "node:http";
+
+import { Static, TSchema } from "@sinclair/typebox";
+import { TypeCheck, TypeCompiler } from "@sinclair/typebox/compiler";
+
+import {
+  createHttpServer,
+  HttpServer,
+  HttpServerOptions,
+  Matcher,
+  Parsers,
+  Request,
+  Response,
+  Route,
+  RouteEvaluator,
+  ServerInstanceContext,
+  ServerInstanceFactory,
+} from "./server";
+import { BadInputError } from "./errors";
+
+export type TypedRequest<Body> = Omit<Request, "body"> & {
+  typed: true;
+  body: Body;
+};
+
+export type Requests<Body> = Request | TypedRequest<Body>;
+
+export function isTypedRequest<Body>(
+  request: Requests<Body>
+): request is TypedRequest<Body> {
+  return "typed" in request;
+}
+
+export interface TypedRoute<Body extends TSchema> {
+  matcher: Matcher;
+  schema: {
+    body: Body;
+  };
+  handler: (
+    request: TypedRequest<Static<Body>>,
+    route: this
+  ) => Promise<Response>;
+}
+
+export function isTypedRoute<Body extends TSchema>(
+  route: Routes<Body>
+): route is TypedRoute<Body> {
+  return "schema" in route;
+}
+
+export type TypedParsers<Body extends TSchema> = Parsers & {
+  Body: (req: IncomingMessage) => Promise<Static<Body>>;
+};
+
+export interface TypedHttpServer<Body extends TSchema> extends HttpServer {
+  addTypedRoute(route: TypedRoute<Body>): this;
+}
+
+export type Routes<Body extends TSchema> = Route | TypedRoute<Body>;
+
+export type TypedServerInstanceFactory<Body extends TSchema> =
+  ServerInstanceFactory<TypedHttpServer<Body>, Routes<Body>>;
+
+export interface TypedHttpServerOptions<Body extends TSchema>
+  extends HttpServerOptions<TypedHttpServer<Body>, TypedParsers<Body>> {
+  routeEvaluator?: RouteEvaluator<Requests<Body>, Response, Routes<Body>>;
+  serverFactory?: TypedServerInstanceFactory<Body>;
+}
+
+export function createCompilerCache<T extends TSchema>() {
+  const cache = new Map<T, TypeCheck<T>>();
+  return {
+    compile(schema: T): TypeCheck<T> {
+      if (cache.has(schema)) {
+        return cache.get(schema)!;
+      } else {
+        const compiler = TypeCompiler.Compile(schema);
+        cache.set(schema, compiler);
+        return compiler;
+      }
+    },
+  };
+}
+
+export function typedServerInstanceFactory<Body extends TSchema>(
+  context: ServerInstanceContext<Routes<Body>>
+): TypedHttpServer<Body> {
+  const { server, routes, port } = context;
+  return {
+    async start() {
+      server.listen(port);
+      await once(server, "listening");
+    },
+    stop() {
+      server.close();
+    },
+    addRoute(route: Route) {
+      routes.push(route);
+      return this;
+    },
+    addTypedRoute(route: TypedRoute<Body>) {
+      routes.push(route);
+      return this;
+    },
+  };
+}
+
+export function createTypedHttpServer<Body extends TSchema>(
+  options: TypedHttpServerOptions<Body>
+): TypedHttpServer<Body> {
+  const compiler = createCompilerCache();
+  const _options: TypedHttpServerOptions<Body> = {
+    ...options,
+    serverFactory: options.serverFactory ?? typedServerInstanceFactory,
+    routeEvaluator: (request, route) => {
+      if (isTypedRoute(route)) {
+        if (route.schema?.body && typeof request.body === "string") {
+          const body = JSON.parse(request.body);
+          const validator = compiler.compile(route.schema.body);
+          if (!validator.Check(body)) {
+            throw new BadInputError("Invalid request body");
+          }
+          const typedRequest: TypedRequest<Static<Body>> = {
+            ...request,
+            typed: true,
+            body,
+          };
+          return route.handler(typedRequest, route);
+        }
+        throw new BadInputError("expected body to be a string");
+      } else if (!isTypedRequest(request)) {
+        return route.handler(request, route);
+      } else {
+        throw new BadInputError("unexpected input");
+      }
+    },
+  };
+  const instance = createHttpServer<TypedHttpServer<Body>, TypedParsers<Body>>(
+    _options
+  );
+
+  return instance;
+}


### PR DESCRIPTION
- esbuild can't make builds any smaller with required TypeBox deps
- provide a simple/extensible base sever that can be typed separately 